### PR TITLE
fix multi instance of DefinePlugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,13 +16,16 @@ const chalk = require('chalk');
 const globby = require('globby');
 const Koa = require('koa');
 const { customAlphabet } = require('nanoid');
-const { DefinePlugin, ProgressPlugin } = require('webpack');
+const { DefinePlugin, ProgressPlugin, version } = require('webpack');
 
 const { init: initHmrPlugin } = require('./plugins/hmr');
 const { init: initRamdiskPlugin } = require('./plugins/ramdisk');
 const { forceError, getLogger } = require('./log');
 const { start } = require('./server');
 const { validate } = require('./validate');
+const { getMajorVersion } = require('./helpers');
+
+const webpackMajorVersion = getMajorVersion(version);
 
 const defaults = {
   // leave `client` undefined
@@ -160,7 +163,6 @@ class WebpackPluginServe extends EventEmitter {
   }
 
   hook(compiler) {
-    this.definePlugin = false;
     const { done, invalid, watchClose, watchRun } = compiler.hooks;
 
     if (!compiler.wpsId) {
@@ -259,11 +261,21 @@ class WebpackPluginServe extends EventEmitter {
       };
 
       const defineObject = Object.assign({}, this.options, compilerData);
-      const defineData = {
-        ʎɐɹɔosǝʌɹǝs: DefinePlugin.runtimeValue(() => JSON.stringify(defineObject), true)
-      };
-      const definePlugin = !this.definePlugin ? new DefinePlugin(defineData) : this.definePlugin;
-      this.definePlugin = definePlugin;
+      let definePlugin;
+      const defineData =
+        webpackMajorVersion >= 5
+          ? {
+              ʎɐɹɔosǝʌɹǝs: DefinePlugin.runtimeValue(() => JSON.stringify(defineObject), true)
+            }
+          : {
+              ʎɐɹɔosǝʌɹǝs: JSON.stringify(defineObject)
+            };
+      if (webpackMajorVersion >= 5) {
+        definePlugin = !this.definePlugin ? new DefinePlugin(defineData) : this.definePlugin;
+        this.definePlugin = definePlugin;
+      } else {
+        definePlugin = new DefinePlugin(defineData);
+      }
 
       definePlugin.apply(compiler);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,6 +160,7 @@ class WebpackPluginServe extends EventEmitter {
   }
 
   hook(compiler) {
+    this.definePlugin = false;
     const { done, invalid, watchClose, watchRun } = compiler.hooks;
 
     if (!compiler.wpsId) {
@@ -240,7 +241,7 @@ class WebpackPluginServe extends EventEmitter {
       });
     });
 
-    watchRun.tapPromise(key, async () => {
+    watchRun.tapPromise(key, async (compiler) => {
       if (!this.state.starting) {
         // ensure we're only trying to start the server once
         this.state.starting = start.bind(this)();
@@ -258,8 +259,11 @@ class WebpackPluginServe extends EventEmitter {
       };
 
       const defineObject = Object.assign({}, this.options, compilerData);
-      const defineData = { ʎɐɹɔosǝʌɹǝs: JSON.stringify(defineObject) };
-      const definePlugin = new DefinePlugin(defineData);
+      const defineData = {
+        ʎɐɹɔosǝʌɹǝs: DefinePlugin.runtimeValue(() => JSON.stringify(defineObject), true)
+      };
+      const definePlugin = !this.definePlugin ? new DefinePlugin(defineData) : this.definePlugin;
+      this.definePlugin = definePlugin;
 
       definePlugin.apply(compiler);
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [x] yes
- [ ] no

If yes, please describe the breakage.

```js
DefinePlugin.runtimeValue
```
is not available on webpack 4.0-4.1

### Please Describe Your Changes
After any code changes in watch mode webpack compiler throw error:
```
DefinePlugin
Conflicting values for 'ʎɐɹɔosǝʌɹǝs'
```
My PR try to prevent the multi-instancing of DefinePlugin

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
