### PR TITLE
Fix error overlay for webpack 5

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -8,9 +8,14 @@
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of this Source Code Form.
 */
+const { version } = require('webpack');
 const router = require('koa-route');
 const stringify = require('json-stringify-safe');
 const stripAnsi = require('strip-ansi');
+
+const { getMajorVersion } = require('./helpers');
+
+const webpackMajorVersion = getMajorVersion(version);
 
 const prep = (data) => stringify(data);
 
@@ -21,6 +26,8 @@ const statsOptions = {
   hash: true,
   modules: true,
   timings: true,
+  errors: true,
+  warnings: true,
   exclude: ['node_modules', 'bower_components', 'components']
 };
 
@@ -59,9 +66,13 @@ const setupRoutes = function setupRoutes() {
             prep({
               action: 'problems',
               data: {
-                errors: errors.slice(0).map((e) => stripAnsi(e)),
+                errors: errors
+                  .slice(0)
+                  .map((e) => (webpackMajorVersion >= 5 ? stripAnsi(e.message) : stripAnsi(e))),
                 hash,
-                warnings: warnings.slice(0).map((e) => stripAnsi(e)),
+                warnings: warnings
+                  .slice(0)
+                  .map((e) => (webpackMajorVersion >= 5 ? stripAnsi(e.message) : stripAnsi(e))),
                 wpsId
               }
             })


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [x] yes
- [ ] no

If yes, please describe the breakage.

- 
- In webpack 4 the format of error messages is a string in webpack 5 is an object with a message field.
- webpack 5 stats object doesn't have errors and warnings information when all: false. We should set up it directly (is not breaking changes to webpack 4)

### Please Describe Your Changes

This PR added support to errors and warnings in error overlay.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
